### PR TITLE
Using customer_code as uid for SSO

### DIFF
--- a/pretix_venueless/views.py
+++ b/pretix_venueless/views.py
@@ -148,12 +148,14 @@ class OrderPositionJoin(EventViewMixin, OrderPositionDetailMixin, View):
         for a in self.position.answers.filter(question_id__in=request.event.settings.venueless_questions).select_related('question'):
             profile['fields'][a.question.identifier] = a.answer
 
+        uid_token = self.order.customer.identifier if self.order.customer else self.position.pseudonymization_id
+
         payload = {
             "iss": request.event.settings.venueless_issuer,
             "aud": request.event.settings.venueless_audience,
             "exp": exp,
             "iat": iat,
-            "uid": self.position.pseudonymization_id,
+            "uid": uid_token,
             "profile": profile,
             "traits": list(
                 {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Modified the SSO payload generation to prioritize using the customer_code as the UID, enhancing the identification process by falling back to pseudonymization_id only if customer_code is not available.

- **Enhancements**:
    - Updated the SSO payload to use customer_code as the UID if available, otherwise fallback to pseudonymization_id.

<!-- Generated by sourcery-ai[bot]: end summary -->