### PR TITLE
Hide view schedule if link is not set

### DIFF
--- a/pretix_venueless/templates/pretix_venueless/order_info.html
+++ b/pretix_venueless/templates/pretix_venueless/order_info.html
@@ -42,15 +42,17 @@
                             </button>
                         </form>
                     </div>
-                    <div class="form-group" style="display: inline-block;">
-                        <form method="post" target="_blank"
-                              action="{% eventurl event 'plugins:pretix_venueless:join' order=order.code position=p.positionid secret=p.web_secret view_schedule=True %}">
-                            {% csrf_token %}
-                            <button class="btn btn-primary btn-lg">
-                                {% trans "View schedule" %}
-                            </button>
-                        </form>
-                    </div>
+                    {% if request.event.settings.venueless_talk_schedule_url %}
+                        <div class="form-group" style="display: inline-block;">
+                            <form method="post" target="_blank"
+                                  action="{% eventurl event 'plugins:pretix_venueless:join' order=order.code position=p.positionid secret=p.web_secret view_schedule=True %}">
+                                {% csrf_token %}
+                                <button class="btn btn-primary btn-lg">
+                                    {% trans "View schedule" %}
+                                </button>
+                            </form>
+                        </div>
+                    {% endif %}
                 </div>
             </li>
         {% empty %}


### PR DESCRIPTION
Hide view schedule if link is not set to avoid internal error

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Hide the 'View schedule' button in the order information template if the schedule link is not configured, preventing potential internal errors.

Bug Fixes:
- Hide the 'View schedule' button if the schedule link is not set to prevent internal errors.

<!-- Generated by sourcery-ai[bot]: end summary -->